### PR TITLE
feat: enconde email in forgot password URL

### DIFF
--- a/backend/src/main/java/br/com/project/backend/controller/UserController.java
+++ b/backend/src/main/java/br/com/project/backend/controller/UserController.java
@@ -10,6 +10,7 @@ import br.com.project.backend.model.User;
 import br.com.project.backend.security.Token;
 import br.com.project.backend.service.TokenResetService;
 import br.com.project.backend.service.UserService;
+import br.com.project.backend.utils.TokenResetUtils;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -105,11 +106,13 @@ public class UserController {
 
         if(tempUser.isPresent()){
             TokenReset tokenReset = tokenResetService.createToken(tempUser.get());
+            String encodedEmail = emailUtils.encodeEmail(tempUser.get().getEmail());
+
             emailUtils.sendEmail(
                     tempUser.get().getEmail(),
                     "Reset Password Token",
                     "Hello " + tempUser.get().getName()
-                    + "\nReset link: http://localhost:5173/reset?email=" +tempUser.get().getEmail()
+                    + "\nReset link: http://localhost:5173/reset?email=" + encodedEmail
                     + "\nToken: " + tokenReset.getToken()
             );
 

--- a/backend/src/main/java/br/com/project/backend/utils/EmailUtils.java
+++ b/backend/src/main/java/br/com/project/backend/utils/EmailUtils.java
@@ -4,10 +4,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-
-
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 @Service
 public class EmailUtils {
@@ -26,5 +26,15 @@ public class EmailUtils {
 
         mailSender.send(message);
     }
-}
 
+    public String encodeEmail(String email){
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hashedBytes = md.digest(email.getBytes());
+            return Base64.getEncoder().encodeToString(hashedBytes);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/br/com/project/backend/utils/TokenResetUtils.java
+++ b/backend/src/main/java/br/com/project/backend/utils/TokenResetUtils.java
@@ -1,7 +1,5 @@
 package br.com.project.backend.utils;
 
-import java.util.Random;
-
 public class TokenResetUtils {
 
     private final int tokenSize = 6;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.datasource.password = root
-spring.datasource.username = root
+spring.datasource.username = avila
 spring.datasource.url = jdbc:mysql://localhost:3306/doit?useTimezone=true&serverTimezone=America/Sao_Paulo
-# spring.datasource.url = jdbc:mysql://localhost:3333/doit?useTimezone=true&serverTimezone=America/Sao_Paulo
+#spring.datasource.url = jdbc:mysql://localhost:3333/doit?useTimezone=true&serverTimezone=America/Sao_Paulo
 spring.jpa.hibernate.ddl-auto=update
 
 spring.mail.host=smtp.gmail.com


### PR DESCRIPTION
Neste pull request, eu implementei as seguintes mudanças:

- Criação de uma nova função na classe EmailUtils para codificar o email presente na URL de forma explícita usando o algoritmo SHA-256. Isso aumenta a segurança ao evitar a exposição direta do email na URL.

- Porém, a partir de agora, o email na URL será representado por seu hash gerado pelo algoritmo SHA-256. Isso afeta a forma como os emails são tratados no sistema, uma vez que o email recuperado da URL será um valor hash. 

- Portanto, apartir de agora será necessário recuperar e tratar corretamente o email hash para obter o valor real do email (presenta na URL).
